### PR TITLE
remove linux_aarch64 from cross-building

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,3 @@
-build_platform:
-  linux_aarch64: linux_64
 github:
   branch_name: main
   tooling_branch_name: main


### PR DESCRIPTION
Accidentally left this out of https://github.com/conda-forge/crane-feedstock/pull/22